### PR TITLE
TLS13 HelloRetryRequest Implementation

### DIFF
--- a/src/libstrongswan/Makefile.am
+++ b/src/libstrongswan/Makefile.am
@@ -240,7 +240,7 @@ $(srcdir)/crypto/proposal/proposal_keywords_static.h: $(srcdir)/crypto/proposal/
 $(srcdir)/crypto/proposal/proposal_keywords_static.c:	$(srcdir)/crypto/proposal/proposal_keywords_static.txt \
 														$(srcdir)/crypto/proposal/proposal_keywords_static.h
 		$(AM_V_GEN) \
-		$(GPERF) -N proposal_get_token_static -m 10 -C -G -c -t -D \
+		$(GPERF) -N proposal_get_token_static -m 10 -C -G -c -t -D --ignore-case \
 			--output-file=$@ $(srcdir)/crypto/proposal/proposal_keywords_static.txt
 
 if STATIC_PLUGIN_CONSTRUCTORS

--- a/src/libstrongswan/crypto/proposal/proposal_keywords_static.txt
+++ b/src/libstrongswan/crypto/proposal/proposal_keywords_static.txt
@@ -1,5 +1,8 @@
 %{
 /*
+ * Copyright (C) 2020 Pascal Knecht
+ * Copyright (C) 2009-2019 Tobias Brunner
+ * Copyright (C) 2009-2018 Martin Willi
  * Copyright (C) 2009-2013 Andreas Steffen
  * HSR Hochschule fuer Technik Rapperswil
  *
@@ -143,35 +146,64 @@ prfaesxcbc,       PSEUDO_RANDOM_FUNCTION, PRF_AES128_XCBC,         0
 prfcamelliaxcbc,  PSEUDO_RANDOM_FUNCTION, PRF_CAMELLIA128_XCBC,    0
 prfaescmac,       PSEUDO_RANDOM_FUNCTION, PRF_AES128_CMAC,         0
 modpnone,         DIFFIE_HELLMAN_GROUP, MODP_NONE,                 0
+modp_none,        DIFFIE_HELLMAN_GROUP, MODP_NONE,                 0
 modpnull,         DIFFIE_HELLMAN_GROUP, MODP_NULL,                 0
+modp_null,        DIFFIE_HELLMAN_GROUP, MODP_NULL,                 0
 modp768,          DIFFIE_HELLMAN_GROUP, MODP_768_BIT,              0
+modp_768,         DIFFIE_HELLMAN_GROUP, MODP_768_BIT,              0
 modp1024,         DIFFIE_HELLMAN_GROUP, MODP_1024_BIT,             0
+modp_1024,        DIFFIE_HELLMAN_GROUP, MODP_1024_BIT,             0
 modp1536,         DIFFIE_HELLMAN_GROUP, MODP_1536_BIT,             0
+modp_1536,        DIFFIE_HELLMAN_GROUP, MODP_1536_BIT,             0
 modp2048,         DIFFIE_HELLMAN_GROUP, MODP_2048_BIT,             0
+modp_2048,        DIFFIE_HELLMAN_GROUP, MODP_2048_BIT,             0
 modp3072,         DIFFIE_HELLMAN_GROUP, MODP_3072_BIT,             0
+modp_3072,        DIFFIE_HELLMAN_GROUP, MODP_3072_BIT,             0
 modp4096,         DIFFIE_HELLMAN_GROUP, MODP_4096_BIT,             0
+modp_4096,        DIFFIE_HELLMAN_GROUP, MODP_4096_BIT,             0
 modp6144,         DIFFIE_HELLMAN_GROUP, MODP_6144_BIT,             0
+modp_6144,        DIFFIE_HELLMAN_GROUP, MODP_6144_BIT,             0
 modp8192,         DIFFIE_HELLMAN_GROUP, MODP_8192_BIT,             0
+modp_8192,        DIFFIE_HELLMAN_GROUP, MODP_8192_BIT,             0
 ecp192,           DIFFIE_HELLMAN_GROUP, ECP_192_BIT,               0
+ecp_192,          DIFFIE_HELLMAN_GROUP, ECP_192_BIT,               0
 ecp224,           DIFFIE_HELLMAN_GROUP, ECP_224_BIT,               0
+ecp_224,          DIFFIE_HELLMAN_GROUP, ECP_224_BIT,               0
 ecp256,           DIFFIE_HELLMAN_GROUP, ECP_256_BIT,               0
+ecp_256,          DIFFIE_HELLMAN_GROUP, ECP_256_BIT,               0
 ecp384,           DIFFIE_HELLMAN_GROUP, ECP_384_BIT,               0
+ecp_384,          DIFFIE_HELLMAN_GROUP, ECP_384_BIT,               0
 ecp521,           DIFFIE_HELLMAN_GROUP, ECP_521_BIT,               0
+ecp_521,          DIFFIE_HELLMAN_GROUP, ECP_521_BIT,               0
 modp1024s160,     DIFFIE_HELLMAN_GROUP, MODP_1024_160,             0
+modp_1024_160,    DIFFIE_HELLMAN_GROUP, MODP_1024_160,             0
 modp2048s224,     DIFFIE_HELLMAN_GROUP, MODP_2048_224,             0
+modp_2048_224,    DIFFIE_HELLMAN_GROUP, MODP_2048_224,             0
 modp2048s256,     DIFFIE_HELLMAN_GROUP, MODP_2048_256,             0
+mod_2048_256,     DIFFIE_HELLMAN_GROUP, MODP_2048_256,             0
 ecp224bp,         DIFFIE_HELLMAN_GROUP, ECP_224_BP,                0
+ecp_224_bp,       DIFFIE_HELLMAN_GROUP, ECP_224_BP,                0
 ecp256bp,         DIFFIE_HELLMAN_GROUP, ECP_256_BP,                0
+ecp_256_bp,       DIFFIE_HELLMAN_GROUP, ECP_256_BP,                0
 ecp384bp,         DIFFIE_HELLMAN_GROUP, ECP_384_BP,                0
+ecp_384_bp,       DIFFIE_HELLMAN_GROUP, ECP_384_BP,                0
 ecp512bp,         DIFFIE_HELLMAN_GROUP, ECP_512_BP,                0
+ecp_512_bp,       DIFFIE_HELLMAN_GROUP, ECP_512_BP,                0
 curve25519,       DIFFIE_HELLMAN_GROUP, CURVE_25519,               0
+curve_25519,      DIFFIE_HELLMAN_GROUP, CURVE_25519,               0
 x25519,           DIFFIE_HELLMAN_GROUP, CURVE_25519,               0
 curve448,         DIFFIE_HELLMAN_GROUP, CURVE_448,                 0
+curve_448,        DIFFIE_HELLMAN_GROUP, CURVE_448,                 0
 x448,             DIFFIE_HELLMAN_GROUP, CURVE_448,                 0
 ntru112,          DIFFIE_HELLMAN_GROUP, NTRU_112_BIT,              0
+ntru_112,         DIFFIE_HELLMAN_GROUP, NTRU_112_BIT,              0
 ntru128,          DIFFIE_HELLMAN_GROUP, NTRU_128_BIT,              0
+ntru_128,         DIFFIE_HELLMAN_GROUP, NTRU_128_BIT,              0
 ntru192,          DIFFIE_HELLMAN_GROUP, NTRU_192_BIT,              0
+ntru_192,         DIFFIE_HELLMAN_GROUP, NTRU_192_BIT,              0
 ntru256,          DIFFIE_HELLMAN_GROUP, NTRU_256_BIT,              0
+ntru_256,         DIFFIE_HELLMAN_GROUP, NTRU_256_BIT,              0
 newhope128,       DIFFIE_HELLMAN_GROUP, NH_128_BIT,                0
+newhope_128,      DIFFIE_HELLMAN_GROUP, NH_128_BIT,                0
 noesn,            EXTENDED_SEQUENCE_NUMBERS, NO_EXT_SEQ_NUMBERS,   0
 esn,              EXTENDED_SEQUENCE_NUMBERS, EXT_SEQ_NUMBERS,      0

--- a/src/libtls/tests/suites/test_socket.c
+++ b/src/libtls/tests/suites/test_socket.c
@@ -408,6 +408,24 @@ static void run_echo_client(echo_server_config_t *config)
 }
 
 /**
+ * Create server/peer configuration
+ */
+static echo_server_config_t *create_config(tls_version_t version, uint16_t port,
+										   bool cauth)
+{
+	echo_server_config_t *config;
+
+	INIT(config,
+		.version = version,
+		.addr = "127.0.0.1",
+		.port = port,
+		.cauth = cauth,
+		.data = chunk_from_chars(0x01,0x02,0x03,0x04,0x05,0x06,0x07,0x08),
+	);
+	return config;
+}
+
+/**
  * Common test wrapper function for different test variants
  */
 static void test_tls(tls_version_t version, uint16_t port, bool cauth, u_int i)
@@ -417,13 +435,7 @@ static void test_tls(tls_version_t version, uint16_t port, bool cauth, u_int i)
 	char suite[128];
 	int count;
 
-	INIT(config,
-		.version = version,
-		.addr = "127.0.0.1",
-		.port = port,
-		.cauth = cauth,
-		.data = chunk_from_chars(0x01,0x02,0x03,0x04,0x05,0x06,0x07,0x08),
-	);
+	config = create_config(version, port, cauth);
 
 	start_echo_server(config);
 
@@ -453,13 +465,7 @@ static void test_tls_curves(tls_version_t version, uint16_t port, bool cauth,
 	char curve[128];
 	int count;
 
-	INIT(config,
-		.version = version,
-		.addr = "127.0.0.1",
-		.port = port,
-		.cauth = cauth,
-		.data = chunk_from_chars(0x01,0x02,0x03,0x04,0x05,0x06,0x07,0x08),
-	);
+	config = create_config(version, port, cauth);
 
 	start_echo_server(config);
 
@@ -477,6 +483,72 @@ static void test_tls_curves(tls_version_t version, uint16_t port, bool cauth,
 
 	free(config);
 }
+
+/**
+ * TLS server version test wrapper function
+ */
+static void test_tls_server(tls_version_t version, uint16_t port, bool cauth,
+							u_int i)
+{
+	echo_server_config_t *client, *server;
+
+	client = create_config(i, port, cauth);
+	server = create_config(version, port, cauth);
+
+	start_echo_server(server);
+
+	run_echo_client(client);
+
+	shutdown(client->fd, SHUT_RDWR);
+	close(client->fd);
+	shutdown(server->fd, SHUT_RDWR);
+	close(server->fd);
+
+	free(client);
+	free(server);
+}
+
+/**
+ * TLS client version test wrapper function
+ */
+static void test_tls_client(tls_version_t version, uint16_t port, bool cauth,
+							u_int i)
+{
+	echo_server_config_t *client, *server;
+
+	client = create_config(version, port, cauth);
+	server = create_config(i, port, cauth);
+
+	start_echo_server(server);
+
+	run_echo_client(client);
+
+	shutdown(client->fd, SHUT_RDWR);
+	close(client->fd);
+	shutdown(server->fd, SHUT_RDWR);
+	close(server->fd);
+
+	free(client);
+	free(server);
+}
+
+START_TEST(test_tls_12_server)
+{
+	test_tls_server(TLS_1_2, 5665, FALSE, _i);
+}
+END_TEST
+
+START_TEST(test_tls_13_server)
+{
+	test_tls_server(TLS_1_3, 5666, FALSE, _i);
+}
+END_TEST
+
+START_TEST(test_tls_13_client)
+{
+	test_tls_client(TLS_1_3, 5667, FALSE, _i);
+}
+END_TEST
 
 START_TEST(test_tls13_curves)
 {
@@ -541,7 +613,25 @@ Suite *socket_suite_create()
 	tcase_add_loop_test(tc, func, 0, \
 						tls_crypto_get_supported_suites(TRUE, version, NULL));
 
+#define add_tls_versions_test(func, from, to) \
+	tcase_add_loop_test(tc, func, from, to+1);
+
 	s = suite_create("socket");
+
+	tc = tcase_create("TLS [1.0..1.3] client to TLS 1.3 server");
+	tcase_add_checked_fixture(tc, setup_creds, teardown_creds);
+	add_tls_versions_test(test_tls_13_server, TLS_1_0, TLS_1_3);
+	suite_add_tcase(s, tc);
+
+	tc = tcase_create("TLS 1.3 client to TLS [1.0..1.3] server");
+	tcase_add_checked_fixture(tc, setup_creds, teardown_creds);
+	add_tls_versions_test(test_tls_13_client, TLS_1_0, TLS_1_3);
+	suite_add_tcase(s, tc);
+
+	tc = tcase_create("TLS [1.0..1.3] client to TLS 1.2 server");
+	tcase_add_checked_fixture(tc, setup_creds, teardown_creds);
+	add_tls_versions_test(test_tls_12_server, TLS_1_0, TLS_1_3);
+	suite_add_tcase(s, tc);
 
 	tc = tcase_create("TLS 1.3/curves");
 	tcase_add_checked_fixture(tc, setup_creds, teardown_creds);

--- a/src/libtls/tests/suites/test_socket.c
+++ b/src/libtls/tests/suites/test_socket.c
@@ -442,6 +442,48 @@ static void test_tls(tls_version_t version, uint16_t port, bool cauth, u_int i)
 	free(config);
 }
 
+/**
+ * TLS curve test wrapper function
+ */
+static void test_tls_curves(tls_version_t version, uint16_t port, bool cauth,
+							u_int i)
+{
+	echo_server_config_t *config;
+	diffie_hellman_group_t *groups;
+	char curve[128];
+	int count;
+
+	INIT(config,
+		.version = version,
+		.addr = "127.0.0.1",
+		.port = port,
+		.cauth = cauth,
+		.data = chunk_from_chars(0x01,0x02,0x03,0x04,0x05,0x06,0x07,0x08),
+	);
+
+	start_echo_server(config);
+
+	count = tls_crypto_get_supported_groups(&groups);
+	ck_assert(i < count);
+	snprintf(curve, sizeof(curve), "%N", diffie_hellman_group_names, groups[i]);
+	lib->settings->set_str(lib->settings, "%s.tls.curve", curve, lib->ns);
+
+	run_echo_client(config);
+
+	free(groups);
+
+	shutdown(config->fd, SHUT_RDWR);
+	close(config->fd);
+
+	free(config);
+}
+
+START_TEST(test_tls13_curves)
+{
+	test_tls_curves(TLS_1_3, 5668, FALSE, _i);
+}
+END_TEST
+
 START_TEST(test_tls13)
 {
 	test_tls(TLS_1_3, 5669, FALSE, _i);
@@ -500,6 +542,12 @@ Suite *socket_suite_create()
 						tls_crypto_get_supported_suites(TRUE, version, NULL));
 
 	s = suite_create("socket");
+
+	tc = tcase_create("TLS 1.3/curves");
+	tcase_add_checked_fixture(tc, setup_creds, teardown_creds);
+	tcase_add_loop_test(tc, test_tls13_curves, 0,
+					 	tls_crypto_get_supported_groups(NULL));
+	suite_add_tcase(s, tc);
 
 	tc = tcase_create("TLS 1.3/anon");
 	tcase_add_checked_fixture(tc, setup_creds, teardown_creds);

--- a/src/libtls/tls_crypto.c
+++ b/src/libtls/tls_crypto.c
@@ -1092,6 +1092,35 @@ static void filter_specific_config_suites(private_tls_crypto_t *this,
 }
 
 /**
+ * Filter key exchange curves by curve user config
+ */
+static bool filter_curve_config(tls_named_group_t curve)
+{
+	enumerator_t *enumerator;
+	char *token, *config;
+
+	config = lib->settings->get_str(lib->settings, "%s.tls.curve", NULL, lib->ns);
+	if (config)
+	{
+		enumerator = enumerator_create_token(config, ",", " ");
+		while (enumerator->enumerate(enumerator, &token))
+		{
+			const proposal_token_t *tok;
+
+			tok = lib->proposal->get_token(lib->proposal, token);
+			if (tok != NULL && tok->type == DIFFIE_HELLMAN_GROUP &&
+				curve == tls_ec_group_to_curve(tok->algorithm))
+			{
+				enumerator->destroy(enumerator);
+				return TRUE;
+			}
+		}
+		enumerator->destroy(enumerator);
+	}
+	return !config;
+}
+
+/**
  * Filter out unsupported suites on given suite array
  */
 static void filter_unsupported_suites(suite_algs_t suites[], int *count)
@@ -1526,29 +1555,52 @@ static struct {
 CALLBACK(group_filter, bool,
 	void *null, enumerator_t *orig, va_list args)
 {
-	diffie_hellman_group_t group, *out;
-	tls_named_group_t *curve;
+	diffie_hellman_group_t group, *group_out;
+	tls_named_group_t curve, *curve_out;
 	char *plugin;
-	int i;
 
-	VA_ARGS_VGET(args, out, curve);
+	VA_ARGS_VGET(args, group_out, curve_out);
 
 	while (orig->enumerate(orig, &group, &plugin))
 	{
-		for (i = 0; i < countof(curves); i++)
+		curve = tls_ec_group_to_curve(group);
+		if (curve)
 		{
-			if (curves[i].group == group)
+			if (group_out)
 			{
-				if (out)
-				{
-					*out = curves[i].group;
-				}
-				if (curve)
-				{
-					*curve = curves[i].curve;
-				}
-				return TRUE;
+				*group_out = group;
 			}
+			if (curve_out)
+			{
+				*curve_out = curve;
+			}
+			return TRUE;
+		}
+	}
+	return FALSE;
+}
+
+CALLBACK(config_filter, bool,
+	void *null, enumerator_t *orig, va_list args)
+{
+	diffie_hellman_group_t group, *group_out;
+	tls_named_group_t curve, *curve_out;
+
+	VA_ARGS_VGET(args, group_out, curve_out);
+
+	while (orig->enumerate(orig, &group, &curve))
+	{
+		if (filter_curve_config(curve))
+		{
+			if (group_out)
+			{
+				*group_out = group;
+			}
+			if (curve_out)
+			{
+				*curve_out = curve;
+			}
+			return TRUE;
 		}
 	}
 	return FALSE;
@@ -1558,8 +1610,10 @@ METHOD(tls_crypto_t, create_ec_enumerator, enumerator_t*,
 	private_tls_crypto_t *this)
 {
 	return enumerator_create_filter(
-							lib->crypto->create_dh_enumerator(lib->crypto),
-							group_filter, NULL, NULL);
+							enumerator_create_filter(
+								lib->crypto->create_dh_enumerator(lib->crypto),
+								group_filter, NULL, NULL),
+							config_filter, NULL, NULL);
 }
 
 METHOD(tls_crypto_t, set_protection, void,
@@ -2317,6 +2371,38 @@ int tls_crypto_get_supported_suites(bool null, tls_version_t version,
 		for (i = 0; i < count; i++)
 		{
 			(*out)[i] = suites[i].suite;
+		}
+	}
+	return count;
+}
+
+/**
+ * See header.
+ */
+int tls_crypto_get_supported_groups(diffie_hellman_group_t **out)
+{
+	enumerator_t *enumerator;
+	diffie_hellman_group_t groups[countof(curves)];
+	diffie_hellman_group_t group;
+	tls_named_group_t curve;
+	int count = 0, i;
+
+	enumerator = enumerator_create_filter(
+							lib->crypto->create_dh_enumerator(lib->crypto),
+							group_filter, NULL, NULL);
+
+	while (enumerator->enumerate(enumerator, &group, &curve))
+	{
+		groups[count++] = group;
+	}
+	enumerator->destroy(enumerator);
+
+	if (out)
+	{
+		*out = calloc(count, sizeof(diffie_hellman_group_t));
+		for (i = 0; i < count; i++)
+		{
+			(*out)[i] = groups[i];
 		}
 	}
 	return count;

--- a/src/libtls/tls_crypto.c
+++ b/src/libtls/tls_crypto.c
@@ -2321,3 +2321,20 @@ int tls_crypto_get_supported_suites(bool null, tls_version_t version,
 	}
 	return count;
 }
+
+/**
+ * See header.
+ */
+tls_named_group_t tls_ec_group_to_curve(diffie_hellman_group_t group)
+{
+	int i;
+
+	for (i = 0; i < countof(curves); i++)
+	{
+		if (curves[i].group == group)
+		{
+			return curves[i].curve;
+		}
+	}
+	return 0;
+}

--- a/src/libtls/tls_crypto.h
+++ b/src/libtls/tls_crypto.h
@@ -670,6 +670,14 @@ int tls_crypto_get_supported_suites(bool null, tls_version_t version,
 									tls_cipher_suite_t **suites);
 
 /**
+ * Get a list of all supported TLS DH groups.
+ *
+ * @param groups		pointer to allocated DH group array, to free(), or NULL
+ * @return				number of curves supported
+ */
+int tls_crypto_get_supported_groups(diffie_hellman_group_t **groups);
+
+/**
  * Get the TLS curve of a given EC DH group
  *
  * @param group			diffie hellman group indicator

--- a/src/libtls/tls_crypto.h
+++ b/src/libtls/tls_crypto.h
@@ -669,4 +669,12 @@ tls_crypto_t *tls_crypto_create(tls_t *tls, tls_cache_t *cache);
 int tls_crypto_get_supported_suites(bool null, tls_version_t version,
 									tls_cipher_suite_t **suites);
 
+/**
+ * Get the TLS curve of a given EC DH group
+ *
+ * @param group			diffie hellman group indicator
+ * @return				TLS group indicator
+ */
+tls_named_group_t tls_ec_group_to_curve(diffie_hellman_group_t group);
+
 #endif /** TLS_CRYPTO_H_ @}*/

--- a/src/libtls/tls_server.c
+++ b/src/libtls/tls_server.c
@@ -948,20 +948,25 @@ METHOD(tls_handshake_t, process, status_t,
 /**
  * Write public key into key share extension
  */
-bool tls_write_key_share(bio_writer_t **key_share, tls_named_group_t group,
-						 diffie_hellman_t *dh)
+bool tls_write_key_share(bio_writer_t **key_share, diffie_hellman_t *dh)
 {
 	bio_writer_t *writer;
+	tls_named_group_t curve;
 	chunk_t pub;
 
-	if (!dh || !dh->get_my_public_value(dh, &pub))
+	if (!dh)
+	{
+		return FALSE;
+	}
+	curve = tls_ec_group_to_curve(dh->get_dh_group(dh));
+	if (!curve || !dh->get_my_public_value(dh, &pub))
 	{
 		return FALSE;
 	}
 	*key_share = writer = bio_writer_create(pub.len + 7);
-	writer->write_uint16(writer, group);
-	if (group == TLS_CURVE25519 ||
-		group == TLS_CURVE448)
+	writer->write_uint16(writer, curve);
+	if (curve == TLS_CURVE25519 ||
+		curve == TLS_CURVE448)
 	{
 		writer->write_data16(writer, pub);
 	}
@@ -1013,7 +1018,7 @@ static status_t send_server_hello(private_tls_server_t *this,
 	   		 tls_extension_names, TLS_EXT_KEY_SHARE);
 		extensions->write_uint16(extensions, TLS_EXT_KEY_SHARE);
 
-		if (!tls_write_key_share(&key_share, this->requested_curve, this->dh))
+		if (!tls_write_key_share(&key_share, this->dh))
 		{
 			this->alert->add(this->alert, TLS_FATAL, TLS_INTERNAL_ERROR);
 			extensions->destroy(extensions);
@@ -1192,29 +1197,6 @@ static status_t send_certificate_request(private_tls_server_t *this,
 }
 
 /**
- * Get the TLS curve of a given EC DH group
- */
-static tls_named_group_t ec_group_to_curve(private_tls_server_t *this,
-                                           diffie_hellman_group_t group)
-{
-	diffie_hellman_group_t current;
-	tls_named_group_t curve;
-	enumerator_t *enumerator;
-
-	enumerator = this->crypto->create_ec_enumerator(this->crypto);
-	while (enumerator->enumerate(enumerator, &current, &curve))
-	{
-		if (current == group)
-		{
-			enumerator->destroy(enumerator);
-			return curve;
-		}
-	}
-	enumerator->destroy(enumerator);
-	return 0;
-}
-
-/**
  * Try to find a curve supported by both, client and server
  */
 static bool find_supported_curve(private_tls_server_t *this,
@@ -1250,7 +1232,7 @@ static status_t send_server_key_exchange(private_tls_server_t *this,
 
 	if (diffie_hellman_group_is_ec(group))
 	{
-		curve = ec_group_to_curve(this, group);
+		curve = tls_ec_group_to_curve(group);
 		if (!curve || (!peer_supports_curve(this, curve) &&
 					   !find_supported_curve(this, &curve)))
 		{

--- a/src/libtls/tls_server.c
+++ b/src/libtls/tls_server.c
@@ -262,6 +262,14 @@ static bool peer_supports_curve(private_tls_server_t *this,
 }
 
 /**
+ * Check if client is currently retrying to connect to the server.
+ */
+static bool retrying(private_tls_server_t *this)
+{
+	return this->state == STATE_INIT && this->requested_curve;
+}
+
+/**
  * Process client hello message
  */
 static status_t process_client_hello(private_tls_server_t *this,
@@ -310,9 +318,11 @@ static status_t process_client_hello(private_tls_server_t *this,
 		switch (extension_type)
 		{
 			case TLS_EXT_SIGNATURE_ALGORITHMS:
+				chunk_free(&this->hashsig);
 				this->hashsig = chunk_clone(extension_data);
 				break;
 			case TLS_EXT_SUPPORTED_GROUPS:
+				chunk_free(&this->curves);
 				this->curves_received = TRUE;
 				this->curves = chunk_clone(extension_data);
 				break;
@@ -451,50 +461,82 @@ static status_t process_client_hello(private_tls_server_t *this,
 	if (this->tls->get_version_max(this->tls) >= TLS_1_3)
 	{
 		diffie_hellman_group_t group;
-		tls_named_group_t curve;
+		tls_named_group_t curve, requesting_curve = 0;
 		enumerator_t *enumerator;
 		chunk_t shared_secret = chunk_empty;
 
 		enumerator = this->crypto->create_ec_enumerator(this->crypto);
 		while (enumerator->enumerate(enumerator, &group, &curve))
 		{
+			if (!requesting_curve &&
+				curve != key_type &&
+				peer_supports_curve(this, curve))
+			{
+				requesting_curve = curve;
+			}
 			if (curve == key_type && peer_supports_curve(this, curve))
 			{
+				DBG1(DBG_TLS, "using key exchange %N",
+					 tls_named_group_names, curve);
 				this->dh = lib->crypto->create_dh(lib->crypto, group);
 				break;
 			}
 		}
 		enumerator->destroy(enumerator);
-		if (!this->dh)
-		{	/* simply fail since HelloRetryRequest is not currently implemented */
-			DBG1(DBG_TLS, "key_type is not within supported group");
-			this->alert->add(this->alert, TLS_FATAL, TLS_HANDSHAKE_FAILURE);
-			return NEED_MORE;
-		}
 
-		if (key_share.len &&
-			key_type != TLS_CURVE25519 &&
-			key_type != TLS_CURVE448)
-		{	/* classic format (see RFC 8446, section 4.2.8.2) */
-			if (key_share.ptr[0] != TLS_ANSI_UNCOMPRESSED)
+		if (!this->dh)
+		{
+			if (retrying(this))
 			{
-				DBG1(DBG_TLS, "DH point format '%N' not supported",
-					 tls_ansi_point_format_names, key_share.ptr[0]);
+				DBG1(DBG_TLS, "already replied with a hello retry request");
+				this->alert->add(this->alert, TLS_FATAL, TLS_UNEXPECTED_MESSAGE);
+				return NEED_MORE;
+			}
+
+			/* TODO: process all client offered key shares, currently only the
+			 * first key share extensions is processed other offered key shares
+			 * are ignored. */
+			if (!requesting_curve)
+			{
+				DBG1(DBG_TLS, "no mutual supported group in client hello");
+				this->alert->add(this->alert, TLS_FATAL, TLS_ILLEGAL_PARAMETER);
+				return NEED_MORE;
+			}
+			this->requested_curve = requesting_curve;
+
+			if (!this->crypto->hash_handshake(this->crypto, NULL))
+			{
+				DBG1(DBG_TLS, "failed to hash handshake messages");
 				this->alert->add(this->alert, TLS_FATAL, TLS_INTERNAL_ERROR);
 				return NEED_MORE;
 			}
-			key_share = chunk_skip(key_share, 1);
 		}
-		if (!key_share.len ||
-			!this->dh->set_other_public_value(this->dh, key_share))
+		else
 		{
-			DBG1(DBG_TLS, "DH key derivation failed");
-			this->alert->add(this->alert, TLS_FATAL, TLS_HANDSHAKE_FAILURE);
+			if (key_share.len &&
+				key_type != TLS_CURVE25519 &&
+				key_type != TLS_CURVE448)
+			{	/* classic format (see RFC 8446, section 4.2.8.2) */
+				if (key_share.ptr[0] != TLS_ANSI_UNCOMPRESSED)
+				{
+					DBG1(DBG_TLS, "DH point format '%N' not supported",
+						 tls_ansi_point_format_names, key_share.ptr[0]);
+					this->alert->add(this->alert, TLS_FATAL, TLS_INTERNAL_ERROR);
+					return NEED_MORE;
+				}
+				key_share = chunk_skip(key_share, 1);
+			}
+			if (!key_share.len ||
+				!this->dh->set_other_public_value(this->dh, key_share))
+			{
+				DBG1(DBG_TLS, "DH key derivation failed");
+				this->alert->add(this->alert, TLS_FATAL, TLS_HANDSHAKE_FAILURE);
+				chunk_clear(&shared_secret);
+				return NEED_MORE;
+			}
 			chunk_clear(&shared_secret);
-			return NEED_MORE;
+			this->requested_curve = 0;
 		}
-		chunk_clear(&shared_secret);
-		this->requested_curve = key_type;
 	}
 
 	this->state = STATE_HELLO_RECEIVED;
@@ -993,7 +1035,15 @@ static status_t send_server_hello(private_tls_server_t *this,
 
 	/* cap legacy version at TLS 1.2 for middlebox compatibility */
 	writer->write_uint16(writer, min(TLS_1_2, version));
-	writer->write_data(writer, chunk_from_thing(this->server_random));
+
+	if (this->requested_curve)
+	{
+		writer->write_data(writer, tls_hello_retry_request_magic);
+	}
+	else
+	{
+		writer->write_data(writer, chunk_from_thing(this->server_random));
+	}
 
 	/* session identifier if we have one */
 	writer->write_data8(writer, this->session);
@@ -1017,22 +1067,31 @@ static status_t send_server_hello(private_tls_server_t *this,
 		DBG2(DBG_TLS, "sending extension: %N",
 	   		 tls_extension_names, TLS_EXT_KEY_SHARE);
 		extensions->write_uint16(extensions, TLS_EXT_KEY_SHARE);
-
-		if (!tls_write_key_share(&key_share, this->dh))
+		if (this->requested_curve)
 		{
-			this->alert->add(this->alert, TLS_FATAL, TLS_INTERNAL_ERROR);
-			extensions->destroy(extensions);
-			return NEED_MORE;
+			DBG1(DBG_TLS, "requesting key exchange with %N",
+				 tls_named_group_names, this->requested_curve);
+			extensions->write_uint16(extensions, 2);
+			extensions->write_uint16(extensions, this->requested_curve);
 		}
-		extensions->write_data16(extensions, key_share->get_buf(key_share));
-		key_share->destroy(key_share);
+		else
+		{
+			if (!tls_write_key_share(&key_share, this->dh))
+			{
+				this->alert->add(this->alert, TLS_FATAL, TLS_INTERNAL_ERROR);
+				extensions->destroy(extensions);
+				return NEED_MORE;
+			}
+			extensions->write_data16(extensions, key_share->get_buf(key_share));
+			key_share->destroy(key_share);
+		}
 
 		writer->write_data16(writer, extensions->get_buf(extensions));
 		extensions->destroy(extensions);
 	}
 
 	*type = TLS_SERVER_HELLO;
-	this->state = STATE_HELLO_SENT;
+	this->state = this->requested_curve ? STATE_INIT : STATE_HELLO_SENT;
 	this->crypto->append_handshake(this->crypto, *type, writer->get_buf(writer));
 	return NEED_MORE;
 }
@@ -1464,8 +1523,8 @@ METHOD(tls_handshake_t, cipherspec_changed, bool,
 	else
 	{
 		if (inbound)
-		{	/* accept ChangeCipherSpec after ServerFinish */
-			return this->state == STATE_FINISHED_SENT;
+		{	/* accept ChangeCipherSpec after ServerFinish or HelloRetryRequest */
+			return this->state == STATE_FINISHED_SENT || retrying(this);
 		}
 		else
 		{
@@ -1480,6 +1539,12 @@ METHOD(tls_handshake_t, change_cipherspec, void,
 	if (this->tls->get_version_max(this->tls) < TLS_1_3)
 	{
 		this->crypto->change_cipher(this->crypto, inbound);
+	}
+
+	if (retrying(this))
+	{	/* client might send a ChangeCipherSpec after a HelloRetryRequest and
+		 * before a new ClientHello which should not cause any state changes */
+		return;
 	}
 
 	if (inbound)


### PR DESCRIPTION
Support for HelloRetryRequest (HRR) handling and enhancement in the test suite to verify connection with all supported curves.

Maybe we should discuss these two points:

- Server does not currently send a ChangeCipherSpec message after a HelloRetryRequest
- Curves can only be set via global settings currently, I do not see any way how to make test cases to automatically verify HRR-functionality.

Regarding the last bullet, the functionality could be implemented by adding an additional setting for curves to the `tls_socket_create`. Is this worthwile or do you see another way to add test suite capability? Would it also make sense to add cipher suite configuration support via `tls_socket_create`?

Thank you in advance for reviewing this change.